### PR TITLE
Return a response when uploading files

### DIFF
--- a/lib/jet/client/files.rb
+++ b/lib/jet/client/files.rb
@@ -21,7 +21,7 @@ module Jet
         gz.close
         gzipped_body = io.string
         response = RestClient.put(url, gzipped_body, headers)
-        @client.decode_json(response.body) if response.code == 200
+        { status: :success } if response.code == 201
       end
 
       def uploaded_files(url, file_type, file_name)

--- a/spec/jet/client/files_spec.rb
+++ b/spec/jet/client/files_spec.rb
@@ -44,11 +44,11 @@ RSpec.describe Jet::Client::Files, '#file_upload' do
       fake_url = 'https://jetupload.blob.core.windows.net/merchant-files/dca10a71128940bf80aca9edee52e7cd?sv=2014-02-14&sr=b&sig=PCIQGWiwzHmdBeEQbFTnOeyAdGowKcQYbTg9OPIvEQo%3D&se=2014-10-15T22%3A23%3A28Z&sp=w'
       fake_body = '{"fake":"json"}'
       allow(RestClient).to receive(:put).with(fake_url, anything, fake_header) { response }
-      allow(response).to receive(:code) { 200 }
+      allow(response).to receive(:code) { 201 }
       allow(response).to receive(:body) { '{}' }
 
       upload_response = client.files.file_upload(fake_url, fake_body)
-      expect(upload_response).to be_empty
+      expect(upload_response[:status]).to eq :success
     end
   end
 


### PR DESCRIPTION
it's not specified in the Jet API documentation, but the upload file endpoint returns a 201 code and not a 200.

I made this change because it's easy to code an implementation expecting the same pattern as in other endpoints where we get `nil` when the request was unsuccessful and a json when it is a success.

I decided to return `{ status: :success }` just as dummy, we could return something else if you prefer.
